### PR TITLE
Remove negative legacy of mysql era

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,14 +21,6 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 29
 
-# Offense count: 2
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/HasManyOrHasOneDependent:
-  Exclude:
-    - 'app/models/account.rb'
-    - 'app/models/use.rb'
-
 # Offense count: 14
 # Configuration parameters: AllowedChars.
 Style/AsciiComments:

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -55,14 +55,11 @@ class AccountsController < ApplicationController
   # DELETE /accounts/1.json
   def destroy
     message = begin
-      @account.destroy
-      { notice: t('controller.success_destroy', model: Account.model_name.human) }
-              rescue ActiveRecord::StatementInvalid => e
-                if e.cause.class == Mysql2::Error &&
-                   e.cause.message.match(/foreign key constraint fails/)
-                  { alert: t('controller.unsuccess_destroy_key_exist', model: Account.model_name.human) }
-                end
-    end
+                @account.destroy
+                { notice: t('controller.success_destroy', model: Account.model_name.human) }
+              rescue ActiveRecord::InvalidForeignKey
+                { alert: t('controller.unsuccess_destroy_key_exist', model: Account.model_name.human) }
+              end
     respond_to do |format|
       format.html { redirect_to accounts_url, message }
       format.json { head :no_content }

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -54,15 +54,17 @@ class AccountsController < ApplicationController
   # DELETE /accounts/1
   # DELETE /accounts/1.json
   def destroy
-    message = begin
-                @account.destroy
-                { notice: t('controller.success_destroy', model: Account.model_name.human) }
-              rescue ActiveRecord::InvalidForeignKey
-                { alert: t('controller.unsuccess_destroy_key_exist', model: Account.model_name.human) }
-              end
     respond_to do |format|
-      format.html { redirect_to accounts_url, message }
-      format.json { head :no_content }
+      if @account.destroy
+        format.html do
+          redirect_to accounts_url,
+                      notice: t('controller.success_destroy', model: Account.model_name.human)
+        end
+        format.json { head :no_content }
+      else
+        format.html { redirect_to accounts_url, alert: @account.errors.full_messages.join(' ') }
+        format.json { render json: @account.errors, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/controllers/uses_controller.rb
+++ b/app/controllers/uses_controller.rb
@@ -55,14 +55,11 @@ class UsesController < ApplicationController
   # DELETE /uses/1.json
   def destroy
     message = begin
-      @use.destroy
-      { notice: t('controller.success_destroy', model: Use.model_name.human) }
-              rescue ActiveRecord::StatementInvalid => e
-                if e.cause.class == Mysql2::Error &&
-                   e.cause.message.match(/foreign key constraint fails/)
-                  { alert: t('controller.unsuccess_destroy_key_exist', model: Use.model_name.human) }
-                end
-    end
+                @use.destroy
+                { notice: t('controller.success_destroy', model: Use.model_name.human) }
+              rescue ActiveRecord::InvalidForeignKey
+                { alert: t('controller.unsuccess_destroy_key_exist', model: Use.model_name.human) }
+              end
     respond_to do |format|
       format.html { redirect_to uses_url, message }
       format.json { head :no_content }

--- a/app/controllers/uses_controller.rb
+++ b/app/controllers/uses_controller.rb
@@ -54,15 +54,14 @@ class UsesController < ApplicationController
   # DELETE /uses/1
   # DELETE /uses/1.json
   def destroy
-    message = begin
-                @use.destroy
-                { notice: t('controller.success_destroy', model: Use.model_name.human) }
-              rescue ActiveRecord::InvalidForeignKey
-                { alert: t('controller.unsuccess_destroy_key_exist', model: Use.model_name.human) }
-              end
     respond_to do |format|
-      format.html { redirect_to uses_url, message }
-      format.json { head :no_content }
+      if @use.destroy
+        format.html { redirect_to uses_url, notice: t('controller.success_destroy', model: Use.model_name.human) }
+        format.json { head :no_content }
+      else
+        format.html { redirect_to uses_url, alert: @use.errors.full_messages.join(' ') }
+        format.json { render json: @use.errors, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -2,7 +2,7 @@
 
 class Account < ApplicationRecord
   belongs_to :use
-  has_many :history
+  has_many :history, dependent: :restrict_with_error
 
   validates :name, presence: true
 end

--- a/app/models/use.rb
+++ b/app/models/use.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Use < ApplicationRecord
-  has_many :account
+  has_many :account, dependent: :restrict_with_error
 
   validates :name, presence: true
 end

--- a/config/locales/03_controller/en.yml
+++ b/config/locales/03_controller/en.yml
@@ -3,7 +3,6 @@ en:
     success_create: "%{model} was successfully created."
     success_update: "%{model} was successfully updated."
     success_destroy: "%{model} was successfully destroyed."
-    unsuccess_destroy_key_exist: "%{model} was unsuccessfully destroy. Associated tables exist."
     success_import: "%{model} was successfully imports."
     unsuccess_import_record_invalid: "%{model} was unsuccessfully imports. The file format is different."
     unsuccess_import_no_choose:  "%{model} was unsuccessfully imports. Please choose the file to be import."

--- a/config/locales/03_controller/ja.yml
+++ b/config/locales/03_controller/ja.yml
@@ -3,7 +3,6 @@ ja:
     success_create: "%{model}の作成に成功しました。"
     success_update: "%{model}の変更に成功しました。"
     success_destroy: "%{model}を削除しました。"
-    unsuccess_destroy_key_exist: "%{model}の削除に失敗しました。 関連づけられたテーブルが存在します。"
     success_import: "%{model}のインポートに成功しました。"
     unsuccess_import_record_invalid: "%{model}のインポートに失敗しました。 選択されたファイルのフォーマットが異なります。"
     unsuccess_import_no_choose:  "%{model}のインポートに失敗しました。 インポートするファイルを選択してください。"

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -173,7 +173,10 @@ RSpec.describe AccountsController, type: :controller do
       expect do
         delete :destroy, params: { id: history.account.id }, session: valid_session
       end.to change(Account, :count).by(0)
-      expect(controller.alert).to eq(I18n.t('controller.unsuccess_destroy_key_exist', model: Account.model_name.human))
+      expect(controller.alert).to(
+        eq(I18n.t('activerecord.errors.messages.restrict_dependent_destroy.has_many',
+                  record: History.model_name.name.downcase))
+      )
     end
   end
 

--- a/spec/controllers/uses_controller_spec.rb
+++ b/spec/controllers/uses_controller_spec.rb
@@ -173,7 +173,10 @@ RSpec.describe UsesController, type: :controller do
       expect do
         delete :destroy, params: { id: account.use.id }, session: valid_session
       end.to change(Use, :count).by(0)
-      expect(controller.alert).to eq(I18n.t('controller.unsuccess_destroy_key_exist', model: Use.model_name.human))
+      expect(controller.alert).to(
+        eq(I18n.t('activerecord.errors.messages.restrict_dependent_destroy.has_many',
+                  record: Account.model_name.name.downcase))
+      )
     end
   end
 


### PR DESCRIPTION
Fixed a change leak when migrating from MySQL to PostgreSQL.

Instead of catching the `ActiveRecord::InvalidForeignKey` exception, specifying `restrict_with_error` for `dependent` can solve the rubocop problem.