### PR TITLE
Version up of binding_of_caller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :development do
 
   # better_errors
   gem 'better_errors', '~> 2.1', '>= 2.1.1'
-  gem 'binding_of_caller', '~> 0.7.2'
+  gem 'binding_of_caller'
 
   # ruby debugger
   gem 'debase'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindex (0.5.0)
-    binding_of_caller (0.7.3)
+    binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     bootsnap (1.4.0)
       msgpack (~> 1.0)
@@ -260,7 +260,7 @@ PLATFORMS
 
 DEPENDENCIES
   better_errors (~> 2.1, >= 2.1.1)
-  binding_of_caller (~> 0.7.2)
+  binding_of_caller
   bootsnap (>= 1.1.0)
   byebug
   coffee-rails (~> 4.2)


### PR DESCRIPTION
Error occurred when launching rails console.

```
before_session hook failed: NoMethodError: undefined method `reject!' for nil:NilClass
Traceback (most recent call last):
/usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:171:in `fork': undefined method `first' for nil:NilClass (NoMethodError)
/usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:171:in `fork': undefined method `reject!' for nil:NilClass (NoMethodError)
/usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:171:in `fork': undefined method `reject!' for nil:NilClass (NoMethodError)
/usr/local/bundle/gems/spring-2.0.2/lib/spring/application.rb:171:in `fork': undefined method `reject!' for nil:NilClass (NoMethodError)
```

reference site: https://codeday.me/jp/qa/20190412/609952.html