### PR TITLE
Speed up docker contener start up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 #   git config --global core.excludesfile '~/.gitignore_global'
 
 # Ignore all logfiles and tempfiles.
+/.docker-sync/*
 /log/*
 /tmp/*
 !/log/.keep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - .:/app
+      - app-volume:/app
       - bundle:/usr/local/bundle
     depends_on:
       - db
@@ -46,5 +46,7 @@ services:
       POSTGRES_PASSWORD: passwd
 
 volumes:
+  app-volume:
+    external: true
   bundle:
   pg_data:

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,0 +1,5 @@
+version: "2"
+syncs:
+  app-volume:
+    src: './'
+    sync_excludes: ['.gitignore', '.git/']


### PR DESCRIPTION
## How to install docker-sync

https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html#installation

## How to use

```
docker-sync start # => Start up volume container for auto copy files.
# docker-compose up or docker-compose run --rm app rspec (etc..)
docker-sync stop  # => Stop volume container. Bat Don't deleteing volume.
# docker volume rm <volume-name> # => If you want to erase volume.
```

If `app-volume` volume does not exist, you will get an error like this (app-volume is a unique name for this system).

```
Creating network "m3_default" with the default driver
ERROR: Volume app-volume declared as external, but could not be found. Please create the volume manually using `docker volume create --name=app-volume` and try again.
```

In that case, please run `docker-sync start`.