### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,10 @@
 log
 tmp
 
+# Ignore installed library files
+vendor/bundle
+node_modules
+
 # Ignore related files of Git
 .git
 .github

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,19 @@
 # Ignore all logfiles and tempfiles.
-/.docker-sync/*
-/log/*
-/tmp/*
-!/log/.keep
-!/tmp/.keep
-*~
+log
+tmp
 
-/.git
-/.github
-.gitignore
+# Ignore related files of Git
+.git
+.github
+.gitignone
 
-# simplecov
-/coverage
+# Ignore related files of Docker
+.dockerignore
+Dockerfile
+docker-compose.yml
 
-# Dev Machines
-.DS_Store
-
+# Ignore design documentation files
 ErModel.mwb
+
+# Ignore files created by simplecov
+coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - 3000:3000
     volumes:
       - .:/app
+      - node-modules:/app/node_modules
       - bundle:/usr/local/bundle
     depends_on:
       - db
@@ -59,4 +60,5 @@ services:
 
 volumes:
   bundle:
+  node-modules:
   pg_data:


### PR DESCRIPTION
Fixed docker image not to include node_modules and vendor/bundle.
Rewritten with reference to the anti-pattern of .dockerignore.
Anti-patterns point out that generic specifications (example .DS_Store) and regular expressions should not be written in .dockerignore.

Referenced document:
https://qiita.com/munisystem/items/b0f08b28e8cc26132212